### PR TITLE
Replace raw XML functionality

### DIFF
--- a/docx.go
+++ b/docx.go
@@ -42,6 +42,10 @@ type Docx struct {
 	footers map[string]string
 }
 
+func (d *Docx) ReplaceRaw(oldString string, newString string, num int) {
+       d.content = strings.Replace(d.content, oldString, newString, num)
+}
+
 func (d *Docx) Replace(oldString string, newString string, num int) (err error) {
 	oldString, err = encode(oldString)
 	if err != nil {


### PR DESCRIPTION
This allows replacing one part of the document with multiple parts (or none).  Instead of just being able to replace the text inside the XML paragraph tags, this allows you to delete the whole paragraph (or insert multiple paragraphs) since you can now insert formatting using the raw underlying XML.