### PR TITLE
Update of docx to allow for reading of in memory files

### DIFF
--- a/docx_test.go
+++ b/docx_test.go
@@ -1,6 +1,8 @@
 package docx
 
 import (
+	"bytes"
+	"io/ioutil"
 	"strings"
 	"testing"
 )
@@ -15,6 +17,34 @@ func loadFile(file string) *Docx {
 	}
 
 	return r.Editable()
+}
+
+func loadFromMemory(file string) *Docx {
+	data, err := ioutil.ReadFile(file)
+	r, err := ReadDocxFromMemory(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		panic(err)
+	}
+
+	return r.Editable()
+}
+
+//Tests that we are able to load a file from a memory array of bytes and do a quick replacement test
+func TestReadDocxFromMemory(t *testing.T) {
+	d := loadFromMemory(testFile)
+
+	if d == nil {
+		t.Error("Doc should not be nill', got ", d)
+	}
+	d.Replace("document.", "line1\r\nline2", 1)
+	d.WriteToFile(testFileResult)
+
+	d = loadFile(testFileResult)
+
+	if strings.Contains(d.content, "This is a word document") {
+		t.Error("Missing 'This is a word document.', got ", d.content)
+	}
+
 }
 
 func TestReplace(t *testing.T) {


### PR DESCRIPTION
Hey!

We decided to use Docx to do some simple templating in one of our projects.
However we required it to be able to work with files that are in memory(byte arrays) since we don't write our files to disk.
I've added a few changes and introduced a new type/template to represent data from a zip file.
This should allow for the project to be expanded in the future to work with zip files of different formats or different data types.
Tests have been updated to ensure loading from memory works.

Let me know if you need anything else updated but we feel this would be a great addition to your project.
Trent