### PR TITLE
Read documents from filesystems(fs.FS) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ func main() {
 	r, err := docx.ReadDocxFile("./template.docx")
 	// Or read from memory
 	// r, err := docx.ReadDocxFromMemory(data io.ReaderAt, size int64)
+	
+	// Or read from a filesystem object:
+	// r, err := docx.ReadDocxFromFS(file string, fs fs.FS)
+	
 	if err != nil {
 		panic(err)
 	}

--- a/docx.go
+++ b/docx.go
@@ -7,6 +7,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"io"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -180,6 +181,21 @@ func replaceHeaderFooter(headerFooter map[string]string, oldString string, newSt
 	}
 
 	return nil
+}
+
+//ReadDocxFromFS opens a docx file from the file system
+func ReadDocxFromFS(file string, fs fs.FS) (*ReplaceDocx, error) {
+	f, err := fs.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	buff := bytes.NewBuffer([]byte{})
+	size, err := io.Copy(buff, f)
+	if err != nil {
+		return nil, err
+	}
+	reader := bytes.NewReader(buff.Bytes())
+	return ReadDocxFromMemory(reader, size)
 }
 
 func ReadDocxFromMemory(data io.ReaderAt, size int64) (*ReplaceDocx, error) {

--- a/docx_test.go
+++ b/docx_test.go
@@ -2,6 +2,7 @@ package docx
 
 import (
 	"bytes"
+	"embed"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -30,12 +31,33 @@ func loadFromMemory(file string) *Docx {
 	return r.Editable()
 }
 
-//Tests that we are able to load a file from a memory array of bytes and do a quick replacement test
+//go:embed TestDocument.docx
+var testFS embed.FS
+
+func loadFromFs(file string) *Docx {
+	r, err := ReadDocxFromFS(strings.TrimPrefix(file, "./"), testFS)
+	if err != nil {
+		panic(err)
+	}
+
+	return r.Editable()
+}
+
+//Tests that we are able to load a file from a filesystem and do a quick replacement test
+func TestReadDocxFromFS(t *testing.T) {
+	d := loadFromFs(testFile)
+	simpleReplacementTest(d, t)
+}
+
+//Tests that we are able to load a file from a memory array of bytes
 func TestReadDocxFromMemory(t *testing.T) {
 	d := loadFromMemory(testFile)
+	simpleReplacementTest(d, t)
+}
 
+func simpleReplacementTest(d *Docx, t *testing.T) {
 	if d == nil {
-		t.Error("Doc should not be nill', got ", d)
+		t.Error("Doc should not be nil', got ", d)
 	}
 	d.Replace("document.", "line1\r\nline2", 1)
 	d.WriteToFile(testFileResult)
@@ -45,7 +67,6 @@ func TestReadDocxFromMemory(t *testing.T) {
 	if strings.Contains(d.content, "This is a word document") {
 		t.Error("Missing 'This is a word document.', got ", d.content)
 	}
-
 }
 
 func TestReplace(t *testing.T) {


### PR DESCRIPTION
This PR implements a method to open a docx file from a filesystem. 
This allows embedding templates into go binaries like this:

```go
// ./templates/ contains a bunch of .docx files
//go:embed templates
var templates embed.FS

func GenerateFromTemplate(templateName string, replace string, with string) error {
    r, err := docx.ReadDocxFromFS("templates/"+templateName, templates)
    ...
}
```