### PR TITLE
#25 add a tag for hard line breaks 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ func main() {
 	// Replace like https://golang.org/pkg/strings/#Replace
 	docx1.Replace("old_1_1", "new_1_1", -1)
 	docx1.Replace("old_1_2", "new_1_2", -1)
+	docx1.Replace("document", "line1{{HardLineBreaks}}line2", -1)
 	docx1.ReplaceLink("http://example.com/", "https://github.com/nguyenthenguyen/docx", 1)
 	docx1.ReplaceHeader("out with the old", "in with the new")
 	docx1.ReplaceFooter("Change This Footer", "new footer")

--- a/docx_test.go
+++ b/docx_test.go
@@ -43,13 +43,13 @@ func loadFromFs(file string) *Docx {
 	return r.Editable()
 }
 
-//Tests that we are able to load a file from a filesystem and do a quick replacement test
+// Tests that we are able to load a file from a filesystem and do a quick replacement test
 func TestReadDocxFromFS(t *testing.T) {
 	d := loadFromFs(testFile)
 	simpleReplacementTest(d, t)
 }
 
-//Tests that we are able to load a file from a memory array of bytes
+// Tests that we are able to load a file from a memory array of bytes
 func TestReadDocxFromMemory(t *testing.T) {
 	d := loadFromMemory(testFile)
 	simpleReplacementTest(d, t)
@@ -75,9 +75,10 @@ func TestReplace(t *testing.T) {
 		replaceWith string
 		expect      string
 	}{
-		{"Windows line breaks", "line1\r\nline2", "line1<w:br/>line2"},
-		{"Mac line breaks", "line1\rline2", "line1<w:br/>line2"},
-		{"Linux line breaks", "line1\nline2", "line1<w:br/>line2"},
+		{"Windows line breaks", "line1\r\nline2", "line1</w:t><w:br/><w:t>line2"},
+		{"Mac line breaks", "line1\rline2", "line1</w:t><w:br/><w:t>line2"},
+		{"Linux line breaks", "line1\nline2", "line1</w:t><w:br/><w:t>line2"},
+		{"hard line breaks", "line1{{HardLineBreaks}}line2", "line1</w:t><w:p></w:p><w:t>line2"},
 		{"Tabs", "line1\tline2", "line1</w:t><w:tab/><w:t>line2"},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Fix issue #25 .  {{HardLineBreaks}} will be replaced by <w:p></w:p>, besides <w:br/>, it's hard line breaks.
```
docx1.Replace("document", "line1{{HardLineBreaks}}line2", -1)
```

And I also update  ``` const NEWLINE = "<w:br/>" ``` with ``` const NEWLINE = "</w:t><w:br/><w:t>" ```, because when I convert this docx to pdf , it will not be recognized as new line, unless I move <w:br/> outside the <w:t>.