### PR TITLE
Add Getters for Headers, Footers, Images, and Links

### DIFF
--- a/docx.go
+++ b/docx.go
@@ -14,13 +14,13 @@ import (
 	"strings"
 )
 
-//Contains functions to work with data from a zip file
+// Contains functions to work with data from a zip file
 type ZipData interface {
 	files() []*zip.File
 	close() error
 }
 
-//Type for in memory zip files
+// Type for in memory zip files
 type ZipInMemory struct {
 	data *zip.Reader
 }
@@ -29,13 +29,13 @@ func (d ZipInMemory) files() []*zip.File {
 	return d.data.File
 }
 
-//Since there is nothing to close for in memory, just nil the data and return nil
+// Since there is nothing to close for in memory, just nil the data and return nil
 func (d ZipInMemory) close() error {
 	d.data = nil
 	return nil
 }
 
-//Type for zip files read from disk
+// Type for zip files read from disk
 type ZipFile struct {
 	data *zip.ReadCloser
 }
@@ -87,6 +87,22 @@ func (d *Docx) GetContent() string {
 
 func (d *Docx) SetContent(content string) {
 	d.content = content
+}
+
+func (d *Docx) GetHeaders() map[string]string {
+	return d.headers
+}
+
+func (d *Docx) GetFooters() map[string]string {
+	return d.footers
+}
+
+func (d *Docx) GetImages() map[string]string {
+	return d.images
+}
+
+func (d *Docx) GetLinks() string {
+	return d.links
 }
 
 func (d *Docx) ReplaceRaw(oldString string, newString string, num int) {
@@ -194,7 +210,7 @@ func replaceHeaderFooter(headerFooter map[string]string, oldString string, newSt
 	return nil
 }
 
-//ReadDocxFromFS opens a docx file from the file system
+// ReadDocxFromFS opens a docx file from the file system
 func ReadDocxFromFS(file string, fs fs.FS) (*ReplaceDocx, error) {
 	f, err := fs.Open(file)
 	if err != nil {


### PR DESCRIPTION
This pull request introduces new getter methods to the docx object, providing users with convenient access to the following parameters:

- Headers: Retrieve the headers from the document.
- Footers: Retrieve the footers from the document.
- Images: Retrieve the images embedded in the document.
- Links: Retrieve the hyperlinks present in the document.

These enhancements improve the functionality of the **docx** library by allowing users to easily access and manipulate document headers, footers, images, and links, which can be useful for various document processing tasks.